### PR TITLE
Refactor ElectricNavigation

### DIFF
--- a/src/ElectricNavigation.js
+++ b/src/ElectricNavigation.js
@@ -8,24 +8,52 @@ import templates from './ElectricNavigation.soy';
 
 class ElectricNavigation extends ElectricNavigationBase {
   attached() {
-    this.toggler = new Toggler({
-      content: `.${this.listClasses}`,
-      header: `.${this.togglerClasses}`,
-      expandedClasses: 'topbar-list-expanded'
-    });
+    // compound selector list matching only the topmost electric navigation menus 
+    const menuSelector = this.menuClasses ? `nav.${this.menuClasses.split(/\s+/).join(',nav.')}` : 'nav';
+
+    // elements that are the topmost electric navigation menus
+    const menuElements = [].slice.call(document.querySelectorAll(menuSelector));
+
+    // array of toggles used by the document
+    this.togglers = menuElements.map(
+      menuElement => {
+        // list element is presumed to be the first child of the menu
+        const listElement = menuElement.firstChild;
+
+        // generated toggle element, inserted before the list element
+        const menuTogglerElement = document.createElement('button');
+
+        menuTogglerElement.className = this.togglerClasses || '';
+
+        menuElement.insertBefore(menuTogglerElement, listElement);
+
+        return new Toggler({
+          content: listElement,
+          header: menuTogglerElement,
+          collapsedClasses: this.collapsedClasses,
+          expandedClasses: this.menuExpandedClasses
+        });
+      }
+    );
   }
 
   disposed() {
-    let toggler = this.toggler;
+    let togglers = this.togglers;
 
-    if (toggler) {
-      toggler.dispose();
+    if (togglers.length) {
+      togglers.forEach(
+        toggler => {
+          toggler.dispose();
+        }
+      );
     }
   }
 }
 
 ElectricNavigation.STATE = {
+  section: {},
   listClasses: {},
+  menuClasses: {},
   togglerClasses: {}
 };
 

--- a/src/ElectricNavigation.soy
+++ b/src/ElectricNavigation.soy
@@ -1,72 +1,60 @@
 {namespace ElectricNavigation}
 
-/**
- * @param section
- * @param? anchorVariant
- * @param? currentDepth
- * @param? currentURL
- * @param? depth
- * @param? elementClasses
- * @param? linkClasses
- * @param? listClasses
- * @param? listItemActiveClasses
- * @param? listItemClasses
- * @param? togglerClasses
- * @param? togglerLabel
- */
 {template .render}
-	{let $localAnchorVariant: $anchorVariant ?: 'basic' /}
-	{let $localCurrentDepth: $currentDepth ?: 0 /}
-	{let $localListItemActiveClasses: $listItemActiveClasses ?: 'active' /}
+	{@param section}
+	{@param? menuClasses: string}
 
 	{if $section.children}
-		<nav class="{$elementClasses ?: ''}">
-			<button class="{$togglerClasses ?: ''}">{$togglerLabel ?: 'Menu'}</button>
-			<ul class="{$listClasses ?: ''}">
-				{foreach $childId in $section.childIds}
-					{let $page: $section.children[$childId] /}
-
-					{if not $page.hidden}
-						<li class="{$listItemClasses ?: ''}{$page.active ? ' ' + $localListItemActiveClasses : ''}">
-							{delcall ElectricNavigation.anchor variant="$localAnchorVariant" data="all"}
-								{param index: index($childId) /}
-								{param page: $page /}
-							{/delcall}
-
-							{if not $depth or $localCurrentDepth + 1 < $depth}
-								{call ElectricNavigation.render}
-									{param anchorVariant: $localAnchorVariant /}
-									{param currentDepth: $localCurrentDepth + 1 /}
-									{param currentURL: $currentURL /}
-									{param depth: $depth /}
-									{param elementClasses: $elementClasses /}
-									{param linkClasses: $linkClasses /}
-									{param listClasses: $listClasses /}
-									{param listItemActiveClasses: $listItemActiveClasses /}
-									{param listItemClasses: $listItemClasses /}
-									{param togglerClasses: $togglerClasses /}
-									{param togglerLabel: $togglerLabel /}
-									{param section: $page /}
-								{/call}
-							{/if}
-						</li>
-					{/if}
-				{/foreach}
-			</ul>
+		<nav{$menuClasses ? } class="{$menuClasses}"{ : ''}>
+			{call .list data="all"}
 		</nav>
 	{/if}
 {/template}
 
-/**
- * @param page
- * @param? linkClasses
- */
+{template .list}
+	{@param section}
+	{@param? anchorVariant: string}
+	{@param? depth: int}
+	{@param? linkClasses: string}
+	{@param? listClasses: string}
+	{@param? listItemActiveClasses: string}
+	{@param? listItemClasses: string}
+	{@param? maxDepth: int}
+	{@param? menuClasses: string}
+
+	{let $localAnchorVariant: $anchorVariant ?: 'basic' /}
+	{let $localDepth: $depth ?: 0 /}
+
+	<ul{$listClasses ? } class="{$listClasses}"{ : ''}>
+		{foreach $childId in $section.childIds}
+			{let $page: $section.children[$childId] /}
+			{let $localListItemActiveClasses: $page.active ? $listItemActiveClasses ?: 'active' : '' /}
+			{let $localListItemClasses: $listItemClasses ? $listItemClasses + ' ' + $localListItemActiveClasses : $localListItemActiveClasses /}
+
+			{if not $page.hidden}
+				<li{$localListItemClasses ? } class="{$localListItemClasses}"{ : ''}>
+					{delcall ElectricNavigation.anchor variant="$localAnchorVariant" data="all"}
+						{param index: index($childId) /}
+					{/delcall}
+
+					{if not $maxDepth or $localDepth + 1 < $maxDepth}
+						<div{$menuClasses ? } class="{$menuClasses}"{ : ''}>
+							{call .list data="all"}
+						</div>
+					{/if}
+				</li>
+			{/if}
+		{/foreach}
+	</ul>
+{/template}
+
 {deltemplate ElectricNavigation.anchor variant="'basic'"}
+	{@param page}
+	{@param? linkClasses: string}
+
 	{if $page.url or $page.redirect}
-		<a class="{$linkClasses ?: ''}" href="{$page.redirect ?: $page.url}">
-			<span>{$page.title ?: 'Missing'}</span>
-		</a>
+		<a{$linkClasses ? } class="{$linkClasses}"{ : ''} href="{$page.redirect ?: $page.url}"><span>{$page.title ?: 'Missing'}</span></a>
 	{else}
-		<span class="{$linkClasses ?: ''}">{$page.title ?: 'Missing'}</span>
+		<span{$linkClasses ? } class="{$linkClasses}"{ : ''}><span>{$page.title ?: 'Missing'}</span></span>
 	{/if}
 {/deltemplate}


### PR DESCRIPTION
- Generates the toggler button instead of adding a non-functional (js required) one to the markup.
- Applies the generated toggler button only to the topmost electric navigation menu.
- Allows configuration of the collapsed and expanded toggler classes.
- Properly supports multiple menu classnames in the JS (bug in all previous versions).
- Does not create empty class attributes when classes are not specified.
- Renames the `elementClasses` property to `menuClasses` to make usage clearer.